### PR TITLE
wash_atカラムをlaundriesテーブルに追加

### DIFF
--- a/backend/app/models/laundry.rb
+++ b/backend/app/models/laundry.rb
@@ -5,5 +5,6 @@ class Laundry < ApplicationRecord
 
   validates :name, presence: true, length: { maximum: 127 }
   validates :description, length: { maximum: 255 }
-  validates :days, presence: true, numericality: { only_integer: true }
+  validates :days, presence: true, unless: :wash_at?, numericality: { only_integer: true }
+  validates :wash_at, presence: true, unless: :days?
 end

--- a/backend/app/models/laundry.rb
+++ b/backend/app/models/laundry.rb
@@ -5,6 +5,9 @@ class Laundry < ApplicationRecord
 
   validates :name, presence: true, length: { maximum: 127 }
   validates :description, length: { maximum: 255 }
-  validates :days, presence: true, unless: :wash_at?, numericality: { only_integer: true }
-  validates :wash_at, presence: true, unless: :days?
+
+  validates :days, presence: true, unless: :wash_at?
+  validates :days, numericality: { only_integer: true }, allow_nil: true
+
+  validates :wash_at, presence: true
 end

--- a/backend/db/migrate/03_create_laundries.rb
+++ b/backend/db/migrate/03_create_laundries.rb
@@ -5,7 +5,8 @@ class CreateLaundries < ActiveRecord::Migration[6.1]
       t.bigint :user_id, null: false
       t.string :name, null: false, limit: 127
       t.string :description, limit: 255
-      t.integer :days, null: false, default: 7, comment: "次の洗濯までの期間、デフォルトは7日"
+      t.integer :days, default: 7, comment: "次の洗濯までの期間、デフォルトは7日"
+      t.date :wash_at, null: false, comment: "次回の洗濯日"
       t.text :notice, comment: "洗濯期間が過ぎたときの通知文"
       t.datetime :deleted_at
       t.timestamps

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -17,7 +17,8 @@ ActiveRecord::Schema.define(version: 4) do
     t.bigint "user_id", null: false
     t.string "name", limit: 127, null: false
     t.string "description"
-    t.integer "days", default: 7, null: false, comment: "次の洗濯までの期間、デフォルトは7日"
+    t.integer "days", default: 7, comment: "次の洗濯までの期間、デフォルトは7日"
+    t.date "wash_at", null: false, comment: "次回の洗濯日"
     t.text "notice", comment: "洗濯期間が過ぎたときの通知文"
     t.datetime "deleted_at"
     t.datetime "created_at", precision: 6, null: false

--- a/backend/spec/factories/laundry.rb
+++ b/backend/spec/factories/laundry.rb
@@ -4,5 +4,6 @@ FactoryBot.define do
     user
     name { Faker::String.random(length: 3..12) }
     days { 5 }
+    wash_at { Time.now.to_date }
   end
 end

--- a/backend/spec/models/laundry_spec.rb
+++ b/backend/spec/models/laundry_spec.rb
@@ -19,9 +19,14 @@ RSpec.describe Laundry, type: :model do
       expect(laundry).not_to be_valid
     end
 
-    it "日数が無ければ無効" do
-      laundry.days = nil
+    it "wash_atが無ければ無効" do
+      laundry.wash_at = nil
       expect(laundry).not_to be_valid
+    end
+
+    it "wash_atがあればdaysがNULLでも無効" do
+      laundry.days = nil
+      expect(laundry).to be_valid
     end
 
     it "日数が数字以外なら無効" do
@@ -33,6 +38,6 @@ RSpec.describe Laundry, type: :model do
       laundry.description = "a" * 256
       expect(laundry).not_to be_valid
     end
-
   end
+
 end


### PR DESCRIPTION
# 概要
resolve #50 

## 追加
`wash_at`カラム
date型
次回に洗濯する日を格納する
このカラムが存在していれば`days`カラムは空でも可能