### PR TITLE
Laundriesのis_displayedによる表示管理

### DIFF
--- a/backend/app/controllers/api/v1/laundries_controller.rb
+++ b/backend/app/controllers/api/v1/laundries_controller.rb
@@ -71,61 +71,8 @@ class Api::V1::LaundriesController < ApplicationController
     end
   end
 
-  # 現在から3日以内にwash_atが来る洗濯物一覧を取得
-  # @return [json] status,data = {id: 洗濯物ID, name: 洗濯物名, image: 画像, limit: 洗濯日まであと何日か}
-  def list
-    today = Time.now.to_date
-    yesterday = Time.current.yesterday #バッチ処理未完成のため一時的に表記
-    three_days_later = today + 3
-    data = []
-
-    # wash_atが今から3日以内のもののみを検索
-    laundries = Laundry.valid
-                       .where(team_id: current_api_v1_user.team.id)
-                       .recent(yesterday, three_days_later)
-
-    # フォーマット化してdataに入れる
-    laundries.each do |laundry|
-      data.push({ id: laundry.id,
-                  name: laundry.name,
-                  image: laundry.image,
-                  limit_days: (laundry.wash_at - today).to_i
-                }
-      )
-    end
-
-    render json: { status: 200, data: data }
-  end
-
   def show
     render json: { status: 200, data: @laundry }
-  end
-
-  # 「洗濯した」用のメソッド
-  # wash_atを今日からdays日後に更新 & is_displayedをfalseに変更
-  # @params [Integer] laundry_id,リクエストボディから取得
-  # @return [json] 更新後wash_at(XX月YY日に変換)
-  def washed
-    today = Time.now.to_date
-
-    if @laundry.update(wash_at: today + @laundry.days,
-                       is_displayed: false)
-      render json: { status: 200, data: @laundry.wash_at.strftime("%m月%d日") }
-    else
-      render json: { status: 400, message: "洗濯日の更新に失敗しました", data: @laundry.errors }
-    end
-  end
-
-  # 「今日は洗濯しない」用のメソッド
-  # is_displayedをfalseに変更
-  # @params [Integer] laundry_id,リクエストボディから取得
-  # @return [json]
-  def un_washed
-    if @laundry.update(is_displayed: false)
-      render json: { status: 200, data: @laundry.wash_at }
-    else
-      render json: { status: 400, message: "洗濯日の更新に失敗しました", data: @laundry.errors }
-    end
   end
 
   def create
@@ -157,6 +104,59 @@ class Api::V1::LaundriesController < ApplicationController
       render json: { status: 200, data: @laundry }
     else
       render json: { status: 400, message: "洗濯物の削除に失敗しました", data: @laundry.errors }
+    end
+  end
+
+  # 現在から3日以内にwash_atが来る洗濯物一覧を取得
+  # @return [json] status,data = {id: 洗濯物ID, name: 洗濯物名, image: 画像, limit: 洗濯日まであと何日か}
+  def list
+    today = Time.now.to_date
+    yesterday = Time.current.yesterday #バッチ処理未完成のため一時的に表記
+    three_days_later = today + 3
+    data = []
+
+    # wash_atが今から3日以内のもののみを検索
+    laundries = Laundry.valid
+                       .where(team_id: current_api_v1_user.team.id)
+                       .recent(yesterday, three_days_later)
+
+    # フォーマット化してdataに入れる
+    laundries.each do |laundry|
+      data.push({ id: laundry.id,
+                  name: laundry.name,
+                  image: laundry.image,
+                  limit_days: (laundry.wash_at - today).to_i
+                }
+      )
+    end
+
+    render json: { status: 200, data: data }
+  end
+
+  # 「洗濯した」用のメソッド
+  # wash_atを今日からdays日後に更新 & is_displayedをfalseに変更
+  # @params [Integer] laundry_id,リクエストボディから取得
+  # @return [json] 更新後wash_at(XX月YY日に変換)
+  def washed
+    today = Time.now.to_date
+
+    if @laundry.update(wash_at: today + @laundry.days,
+                       is_displayed: false)
+      render json: { status: 200, data: @laundry.wash_at.strftime("%m月%d日") }
+    else
+      render json: { status: 400, message: "洗濯日の更新に失敗しました", data: @laundry.errors }
+    end
+  end
+
+  # 「今日は洗濯しない」用のメソッド
+  # is_displayedをfalseに変更
+  # @params [Integer] laundry_id,リクエストボディから取得
+  # @return [json]
+  def un_washed
+    if @laundry.update(is_displayed: false)
+      render json: { status: 200, data: @laundry.wash_at }
+    else
+      render json: { status: 400, message: "洗濯日の更新に失敗しました", data: @laundry.errors }
     end
   end
 

--- a/backend/app/controllers/api/v1/laundries_controller.rb
+++ b/backend/app/controllers/api/v1/laundries_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::LaundriesController < ApplicationController
   before_action :authenticate_api_v1_user!
-  before_action :set_laundry, only: [:show, :update, :destroy, :washed]
+  before_action :set_laundry, only: [:show, :update, :destroy, :washed, :un_washed]
 
   # statusと、チームに所属する洗濯物全てについてデータをjsonで返却する
   # @return [json] status,data = {id: 洗濯物ID, name: 洗濯物名, image: 画像, weekly: その週の洗濯する日か否かの配列}
@@ -82,7 +82,7 @@ class Api::V1::LaundriesController < ApplicationController
     # wash_atが今から3日以内のもののみを検索
     laundries = Laundry.valid
                        .where(team_id: current_api_v1_user.team.id)
-                       .recent(yesterday,three_days_later)
+                       .recent(yesterday, three_days_later)
 
     # フォーマット化してdataに入れる
     laundries.each do |laundry|
@@ -112,7 +112,19 @@ class Api::V1::LaundriesController < ApplicationController
                        is_displayed: false)
       render json: { status: 200, data: @laundry.wash_at.strftime("%m月%d日") }
     else
-      render json: { status: 400,message: "洗濯日の更新に失敗しました", data: @laundry.errors }
+      render json: { status: 400, message: "洗濯日の更新に失敗しました", data: @laundry.errors }
+    end
+  end
+
+  # 「今日は洗濯しない」用のメソッド
+  # is_displayedをfalseに変更
+  # @params [Integer] laundry_id,リクエストボディから取得
+  # @return [json]
+  def un_washed
+    if @laundry.update(is_displayed: false)
+      render json: { status: 200, data: @laundry.wash_at }
+    else
+      render json: { status: 400, message: "洗濯日の更新に失敗しました", data: @laundry.errors }
     end
   end
 

--- a/backend/app/controllers/api/v1/laundries_controller.rb
+++ b/backend/app/controllers/api/v1/laundries_controller.rb
@@ -102,13 +102,14 @@ class Api::V1::LaundriesController < ApplicationController
   end
 
   # 「洗濯した」用のメソッド
-  # wash_atを今日からdays日後に更新
+  # wash_atを今日からdays日後に更新 & is_displayedをfalseに変更
   # @params [Integer] laundry_id,リクエストボディから取得
   # @return [json] 更新後wash_at(XX月YY日に変換)
   def washed
     today = Time.now.to_date
 
-    if @laundry.update(wash_at: today + @laundry.days)
+    if @laundry.update(wash_at: today + @laundry.days,
+                       is_displayed: false)
       render json: { status: 200, data: @laundry.wash_at.strftime("%m月%d日") }
     else
       render json: { status: 400,message: "洗濯日の更新に失敗しました", data: @laundry.errors }

--- a/backend/app/controllers/api/v1/laundries_controller.rb
+++ b/backend/app/controllers/api/v1/laundries_controller.rb
@@ -118,6 +118,7 @@ class Api::V1::LaundriesController < ApplicationController
     # wash_atが今から3日以内のもののみを検索
     laundries = Laundry.valid
                        .where(team_id: current_api_v1_user.team.id)
+                       .where(is_displayed: true)
                        .recent(yesterday, three_days_later)
 
     # フォーマット化してdataに入れる

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
       resources :laundries, id: /\d+/
       get "/laundries/list", to: "laundries#list"
       put "/laundries/washed", to: "laundries#washed"
+      put "/laundries/un_washed", to: "laundries#un_washed"
       resources :laundry_histories, only: [:index, :show, :create, :destroy]
 
       # ログイン用

--- a/backend/db/migrate/03_create_laundries.rb
+++ b/backend/db/migrate/03_create_laundries.rb
@@ -9,7 +9,7 @@ class CreateLaundries < ActiveRecord::Migration[6.1]
       t.date :wash_at, null: false, default: -> { '(CURRENT_DATE + INTERVAL 7 DAY)' }, comment: "次回の洗濯日"
       t.text :notice, comment: "洗濯期間が過ぎたときの通知文"
       t.string :image, default: "default", null: false, limit: 127
-      t.boolean :is_displayed, null: false, default: "false"
+      t.boolean :is_displayed, null: false, default: "false", comment: "その日画面に出力するか否か"
       t.datetime :deleted_at
       t.timestamps
     end

--- a/backend/db/migrate/03_create_laundries.rb
+++ b/backend/db/migrate/03_create_laundries.rb
@@ -9,6 +9,7 @@ class CreateLaundries < ActiveRecord::Migration[6.1]
       t.date :wash_at, null: false, default: -> { '(CURRENT_DATE + INTERVAL 7 DAY)' }, comment: "次回の洗濯日"
       t.text :notice, comment: "洗濯期間が過ぎたときの通知文"
       t.string :image, default: "default", null: false, limit: 127
+      t.boolean :is_displayed, null: false, default: "false"
       t.datetime :deleted_at
       t.timestamps
     end

--- a/backend/db/migrate/03_create_laundries.rb
+++ b/backend/db/migrate/03_create_laundries.rb
@@ -9,7 +9,7 @@ class CreateLaundries < ActiveRecord::Migration[6.1]
       t.date :wash_at, null: false, default: -> { '(CURRENT_DATE + INTERVAL 7 DAY)' }, comment: "次回の洗濯日"
       t.text :notice, comment: "洗濯期間が過ぎたときの通知文"
       t.string :image, default: "default", null: false, limit: 127
-      t.boolean :is_displayed, null: false, default: "false", comment: "その日画面に出力するか否か"
+      t.boolean :is_displayed, null: false, default: true, comment: "画面に出力するか否か"
       t.datetime :deleted_at
       t.timestamps
     end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 4) do
     t.date "wash_at", default: -> { "(curdate() + interval 7 day)" }, null: false, comment: "次回の洗濯日"
     t.text "notice", comment: "洗濯期間が過ぎたときの通知文"
     t.string "image", limit: 127, default: "default", null: false
+    t.boolean "is_displayed", default: true, null: false, comment: "画面に出力するか否か"
     t.datetime "deleted_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/backend/spec/requests/v1/laundries_spec.rb
+++ b/backend/spec/requests/v1/laundries_spec.rb
@@ -148,6 +148,16 @@ RSpec.describe "LaundriesAPI", type: :request do
       end
     end
 
+    context "is_displayedがfalseの場合" do
+      let(:limit) { rand(0...3) }
+      let!(:laundry) { FactoryBot.create(:laundry, wash_at: Time.now.to_date + limit, team_id: user.team_id,
+                                         is_displayed: false) }
+      it "3日以内でもデータが取得できない" do
+        subject
+        expect(json['data'].length).to eq(0)
+        expect(response.status).to eq(200)
+      end
+    end
   end
 
   describe "PUT /api/v1/laundries/washed" do

--- a/backend/spec/requests/v1/laundries_spec.rb
+++ b/backend/spec/requests/v1/laundries_spec.rb
@@ -82,17 +82,24 @@ RSpec.describe "LaundriesAPI", type: :request do
     context "正しい洗濯物IDを指定した場合" do
       let!(:laundry) { FactoryBot.create(:laundry, team_id: user.team_id) }
       it 'wash_atの更新' do
-        updated_wash_at = (Time.now.to_date + laundry[:days]).strftime("%m月%d日")
-        subject
+        expect { subject }.to change { Laundry.find(laundry.id).wash_at }
+                                .from(laundry.wash_at)
+                                .to(Time.now.to_date + laundry[:days])
         expect(response.status).to eq(200)
+        updated_wash_at = (Time.now.to_date + laundry[:days]).strftime("%m月%d日")
         expect(json['data']).to eq(updated_wash_at)
+      end
+
+      it 'is_displayedをfalseに更新' do
+        expect { subject }.to change { Laundry.find(laundry.id).is_displayed }.from(true).to(false)
+        expect(response.status).to eq(200)
       end
     end
 
     context "異なるチームの洗濯物ID 又は 不正なIDを指定した場合" do
       let!(:laundry) { FactoryBot.create(:laundry) }
       it 'データが変更されないこと' do
-        subject
+        expect { subject }.not_to change { laundry }
         expect(json['message']).to include("失敗")
         expect(response.status).to eq(200)
       end

--- a/backend/spec/requests/v1/laundries_spec.rb
+++ b/backend/spec/requests/v1/laundries_spec.rb
@@ -99,6 +99,26 @@ RSpec.describe "LaundriesAPI", type: :request do
     end
   end
 
+  describe "PUT /api/v1/laundries/un_washed" do
+    subject { put "/api/v1/laundries/un_washed", headers: auth_tokens, params: { id: laundry.id } }
+
+    context "正しい洗濯物IDを指定した場合" do
+      let!(:laundry) { FactoryBot.create(:laundry, team_id: user.team_id) }
+      it 'is_displayedをfalseに更新' do
+        expect { subject }.to change { Laundry.find(laundry.id).is_displayed }.from(true).to(false)
+        expect(response.status).to eq(200)
+      end
+    end
+
+    context "異なるチームの洗濯物ID 又は 不正なIDを指定した場合" do
+      let!(:laundry) { FactoryBot.create(:laundry) }
+      it 'データが変更されないこと' do
+        expect { subject }.not_to change { laundry.is_displayed }
+        expect(response.status).to eq(200)
+      end
+    end
+  end
+
   describe "POST /api/v1/laundries" do
     subject { post '/api/v1/laundries', headers: auth_tokens, params: valid_params }
     let!(:valid_params) { { name: "#{user.name}の洗濯物",

--- a/backend/spec/requests/v1/laundries_spec.rb
+++ b/backend/spec/requests/v1/laundries_spec.rb
@@ -127,32 +127,27 @@ RSpec.describe "LaundriesAPI", type: :request do
   describe "GET /laundries/list" do
     subject { get "/api/v1/laundries/list", headers: auth_tokens }
 
-    context "wash_at当日の場合" do
-      let!(:laundry) { FactoryBot.create(:laundry, wash_at: Time.now.to_date, team_id: user.team_id) }
-      it "limit_daysが0" do
-        subject
-        expect(json['data'].first["limit_days"]).to eq(0)
-        expect(response.status).to eq(200)
+    context "is_displayedがtrueの場合" do
+      context "wash_at3日前〜当日の場合" do
+        let(:limit) { rand(0...3) }
+        let!(:laundry) { FactoryBot.create(:laundry, wash_at: Time.now.to_date + limit, team_id: user.team_id) }
+        it "limit_daysと期間が同一" do
+          subject
+          expect(json['data'].first["limit_days"]).to eq(limit)
+          expect(response.status).to eq(200)
+        end
+      end
+
+      context "wash_atが4日後の場合" do
+        let!(:laundry) { FactoryBot.create(:laundry, wash_at: Time.now.to_date + 4, team_id: user.team_id) }
+        it "データが取得されない" do
+          subject
+          expect(json['data'].length).to eq(0)
+          expect(response.status).to eq(200)
+        end
       end
     end
 
-    context "wash_atが3日後の場合" do
-      let!(:laundry) { FactoryBot.create(:laundry, wash_at: Time.now.to_date + 3, team_id: user.team_id) }
-      it "limit_daysが3" do
-        subject
-        expect(json['data'].first["limit_days"]).to eq(3)
-        expect(response.status).to eq(200)
-      end
-    end
-
-    context "wash_atが4日後の場合" do
-      let!(:laundry) { FactoryBot.create(:laundry, wash_at: Time.now.to_date + 4, team_id: user.team_id) }
-      it "データが取得されない" do
-        subject
-        expect(json['data'].length).to eq(0)
-        expect(response.status).to eq(200)
-      end
-    end
   end
 
   describe "PUT /api/v1/laundries/washed" do

--- a/frontend/src/lib/api/laundries.js
+++ b/frontend/src/lib/api/laundries.js
@@ -69,3 +69,12 @@ export const deleteLaundry = (id) => {
 export const washed = (laundryId) => {
     return client.put(`/laundries/washed`, {id: laundryId}, {headers})
 }
+
+/**
+ * 今日は洗濯しない
+ * @param laundry_id
+ * @returns {Promise<AxiosResponse<any>>}
+ */
+export const unWashed = (laundryId) => {
+    return client.put(`/laundries/un_washed`, {id: laundryId}, {headers})
+}


### PR DESCRIPTION
# 概要
resolve #91 

<br>

# Todo
- [x] laundries `is_displayed`カラムの作成
boolean default:true

- [x] laundries#washed
実行時`is_displayed`を`false`に変更する

- [x] laundries#un_washed
`is_displayed`を`false`に変更する

- [x] laundries#listで`is_displayed`がfalseのものは非表示にする

- [x] フロントからのリクエスト追加
<br>

# やりたいこと
`is_displayed` = **その日トップ画面に洗濯物を表示するか否か**

以下はトップ画面に非表示になるようにしたい
- その日に洗濯したもの（「洗濯する」ボタンを押したもの）
- その日は洗濯しないもの（「今日は洗濯しない」ボタンを押したもの）

が、次の日や、次の洗濯日が近づいてきたら表示するようにしたい

<br>

## 流れ
通常
`is_displayed`：true

↓

「洗濯した」 or 「今日は洗濯しない」
`is_displayed`：false

↓

その日が終わったらバッチ処理でtrueにしておく
`is_displayed`：true

↓

次の洗濯日が近づいてきた（3日前）ら表示される
`is_displayed`：true